### PR TITLE
Fix max height class for open sections

### DIFF
--- a/client/src/pages/student/CourseDetails.jsx
+++ b/client/src/pages/student/CourseDetails.jsx
@@ -170,7 +170,7 @@ const CourseDetails = () => {
 
 									<div
 										className={`overflow-hidden transition-all duration-300 ${
-											openSections[index] ? "max-h-9g" : "max-h-0"
+											openSections[index] ? "max-h-96" : "max-h-0"
 										}`}
 									>
 										<ul className="list-disc md:pl-10 pl-4 pr-4 py-2 text-gray-600 border-t border-gray-300">


### PR DESCRIPTION
Fixed invalid Tailwind max-height class that was breaking section expand animation.